### PR TITLE
Fix LED refresh sending null Z-Wave value when a tracked entity is `unknown`

### DIFF
--- a/ZEN32-control-track.yaml
+++ b/ZEN32-control-track.yaml
@@ -1178,7 +1178,7 @@ action:
         # will be 'None', and we safely skip executing the Z-Wave commands.
         - if:
             - condition: template
-              value_template: "{{ condition.state != 'None' }}"
+              value_template: "{{ condition.state is not none }}"
           then:
             # ===================================================================
             # "FUNCTION": &fn_send_zwave_led_commands
@@ -1289,7 +1289,7 @@ action:
               # Validate and call the Z-Wave execution function
               - if:
                   - condition: template
-                    value_template: "{{ condition.state != 'None' }}"
+                    value_template: "{{ condition.state is not none }}"
                 then:
                   sequence: *fn_send_zwave_led_commands
 


### PR DESCRIPTION
## Problem

The guard meant to skip the Z-Wave LED writes for an untracked state compares an actual `None` to the **string** `'None'`:

```yaml
- if:
    - condition: template
      value_template: "{{ condition.state != 'None' }}"
```

`fn_calc_led_vars` sets `condition = dict(state=None, color=None, brightness=None)` in its `{% else %}` branch — i.e. whenever the tracked entity's state is **not** in `on_states`/`off_states` and is **not** exactly `"unavailable"`. The most common such state is `"unknown"`.

Home Assistant native-parses that rendered dict, so `condition.state` is a real Python `None`. Therefore `condition.state != 'None'` is **always `True`** (`None` is not the string `'None'`), the guard fails to skip, and the sequence calls `zwave_js.set_config_parameter` with a null value:

```
expected int for dictionary value @ data['value']
```

This is easiest to hit on the **HassStart universal refresh**: after the 60-second delay the blueprint loops every tracked entity, and any still reporting `unknown` (common right after a restart, before the device/integration has reported) trips it.

## Reproduction

Verified on Home Assistant Core 2026.7.2 with blueprint v2026.2.0 by running `fn_calc_led_vars`' exact construct in a throwaway automation and reading the trace:

```
target_state = "unknown"
condition    = {state: null, color: null, brightness: null}   # state is real None
{{ condition.state != 'None' }}  →  true                      # guard does NOT skip
→ proceeds to zwave_js.set_config_parameter with a null value
```

Using `{{ condition.state is not none }}` instead, the same input correctly evaluates `false` and the write is skipped.

## Fix

Two-line change — use the identity test at both guard sites (the on-press path and the universal-refresh loop):

```diff
- value_template: "{{ condition.state != 'None' }}"
+ value_template: "{{ condition.state is not none }}"
```

Buttons/scenes are unaffected; this only makes the LED-tracking guard skip correctly for genuinely untracked/unknown states.